### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/hphp/tools/gdb/pretty.py
+++ b/hphp/tools/gdb/pretty.py
@@ -371,7 +371,7 @@ def lookup_function(val):
 
     # Get the type name.
     typename = t.tag
-    if typename == None:
+    if typename is None:
         return None
 
     # Iterate over local dict of types to determine if a printer is registered


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:hhvm?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:hhvm?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
