### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/hphp/hack/src/h2tp/test/converter_test_base.py
+++ b/hphp/hack/src/h2tp/test/converter_test_base.py
@@ -34,11 +34,11 @@ class ConverterTestCase(unittest.TestCase):
             return
         (success, in_res) = in_eng.execute_file(in_file)
         if not success:
-            msg = "error executing file %s \n" % in_file
+            msg = "error executing file {0!s} \n".format(in_file)
             self.fail(msg + in_res)
         (success, out_res) = out_eng.execute_file(out_file)
         if not success:
-            msg = "error executing file %s \n" % out_file
+            msg = "error executing file {0!s} \n".format(out_file)
             self.fail(msg + out_res)
         if (in_res != out_res):
             message = ''.join(difflib.unified_diff(
@@ -143,7 +143,7 @@ class ConverterTestCase(unittest.TestCase):
             with open(out_path, "r") as f:
                 expected_output = f.read()
         except IOError:
-            self.fail("Expected output %s not provided/readable" % out_path)
+            self.fail("Expected output {0!s} not provided/readable".format(out_path))
         expected_output = self.normalize(
             Template(expected_output).safe_substitute(filename=in_path))
         actual_output = self.normalize(actual_output)

--- a/hphp/hack/src/h2tp/test/engine.py
+++ b/hphp/hack/src/h2tp/test/engine.py
@@ -20,7 +20,7 @@ class Engine(object):
         return bool(self.cmd())
 
     def code(self, file_path):
-        return "require_once('%s');" % file_path
+        return "require_once('{0!s}');".format(file_path)
 
     def execute_file(self, file_path):
         proc = subprocess.Popen([self.cmd(), '-r', self.code(file_path)],

--- a/hphp/hack/src/h2tp/test/test_generation/generate_tests.py
+++ b/hphp/hack/src/h2tp/test/test_generation/generate_tests.py
@@ -184,9 +184,9 @@ def compute_additional_paths(options):
     )
     options.test_dir = os.path.join(options.code_dir, 'test')
     if options.binary.find("buck-out") < 0:
-        options.gen_file_dir = "%s/test" % options.install_dir
+        options.gen_file_dir = "{0!s}/test".format(options.install_dir)
     else:
-        options.gen_file_dir = "%s/" % options.install_dir
+        options.gen_file_dir = "{0!s}/".format(options.install_dir)
 
     options.gen_file_path = os.path.join(
         options.gen_file_dir,

--- a/hphp/hack/test/integration/test_save_restore.py
+++ b/hphp/hack/test/integration/test_save_restore.py
@@ -24,10 +24,10 @@ def write_load_config(repo_dir, saved_state_path, changed_files=[]):
     with open(os.path.join(repo_dir, 'server_options.sh'), 'w') as f:
         f.write(r"""
 #! /bin/sh
-echo %s
-""" % saved_state_path)
+echo {0!s}
+""".format(saved_state_path))
         for fn in changed_files:
-            f.write("echo %s\n" % fn)
+            f.write("echo {0!s}\n".format(fn))
         os.fchmod(f.fileno(), 0o700)
 
     with open(os.path.join(repo_dir, '.hhconfig'), 'w') as f:
@@ -35,8 +35,8 @@ echo %s
         # be passing this command some command-line options
         f.write(r"""
 # some comment
-load_script = %s
-        """ % os.path.join(repo_dir, 'server_options.sh'))
+load_script = {0!s}
+        """.format(os.path.join(repo_dir, 'server_options.sh')))
 
 class TestSaveRestore(unittest.TestCase):
     @classmethod
@@ -158,7 +158,7 @@ class TestSaveRestore(unittest.TestCase):
             state_fn)
         server_proc = self.start_hh_server()
         ensure_output_contains(server_proc.stderr,
-                'Load state found at %s.' % state_fn)
+                'Load state found at {0!s}.'.format(state_fn))
 
         self.check_cmd(self.initial_errors)
         touch(os.path.join(self.repo_dir, 'foo_1.php'))
@@ -415,8 +415,8 @@ echo "$2" >> {out}
         with open(os.path.join(self.repo_dir, '.hhconfig'), 'w') as f:
             f.write(r"""
 # some comment
-load_script = %s
-            """ % os.path.join(self.repo_dir, 'server_options.sh'))
+load_script = {0!s}
+            """.format(os.path.join(self.repo_dir, 'server_options.sh')))
 
         proc_call([
             self.hh_client,

--- a/hphp/hack/test/integration/utils.py
+++ b/hphp/hack/test/integration/utils.py
@@ -46,7 +46,7 @@ def ensure_output_contains(f, s, timeout=5):
     process hangs
     """
     def handler(signo, frame):
-        raise AssertionError('Failed to find %s in output' % s)
+        raise AssertionError('Failed to find {0!s} in output'.format(s))
 
     try:
         signal.signal(signal.SIGALRM, handler)

--- a/hphp/hack/test/verify.py
+++ b/hphp/hack/test/verify.py
@@ -46,7 +46,7 @@ def check_results(fnames, out_ext, expect_ext):
     success = all(results)
     total = len(fnames)
     if success:
-        print("All %d tests passed!" % total)
+        print("All {0:d} tests passed!".format(total))
     else:
         failures = list(compress(fnames, map(not_, results)))
         print("Failures:\n" + " ".join(failures))
@@ -59,7 +59,7 @@ def check_results(fnames, out_ext, expect_ext):
                 diff = difflib.ndiff(
                     expected.splitlines(1),
                     actual.splitlines(1))
-                print("Details for the failed test %s:" % f)
+                print("Details for the failed test {0!s}:".format(f))
                 print("\n>>>>>  Expected output  >>>>>>\n")
                 print(expected)
                 print("\n=====   Actual output   ======\n")
@@ -68,7 +68,7 @@ def check_results(fnames, out_ext, expect_ext):
                 print("\n>>>>>       Diff        >>>>>>>\n")
                 print(''.join(diff))
                 print("\n<<<<<     End Diff      <<<<<<<\n")
-        print("Failed %d out of %d tests." % (len(failures), total))
+        print("Failed {0:d} out of {1:d} tests.".format(len(failures), total))
     return success
 
 def get_file_content(fname, ext):
@@ -124,8 +124,8 @@ def list_test_files(root, disabled_ext):
                     disabled_ext))
         return result
     else:
-        raise Exception('Could not find test file or directory at %s' %
-            args.test_path)
+        raise Exception('Could not find test file or directory at {0!s}'.format(
+            args.test_path))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -152,7 +152,7 @@ if __name__ == '__main__':
     dump_on_failure = args.diff
 
     if not os.path.isfile(args.program):
-        raise Exception('Could not find program at %s' % args.program)
+        raise Exception('Could not find program at {0!s}'.format(args.program))
 
     files = list_test_files(args.test_path, args.disabled_extension)
 

--- a/hphp/hack/tools/fixme/fixme.py
+++ b/hphp/hack/tools/fixme/fixme.py
@@ -62,8 +62,7 @@ def patch(path, patches, explanation):
             if is_parse_error(code):
                 raise ParseException()
             fixme_line = \
-                    "%s/* HH_FIXME[%d]: %s */\n" % \
-                    (whitespace, code, explanation)
+                    "{0!s}/* HH_FIXME[{1:d}]: {2!s} */\n".format(whitespace, code, explanation)
             file_lines.insert(line, fixme_line)
 
     with open(path, 'w') as f:
@@ -88,9 +87,9 @@ def main(args):
             patch(path, patches, explanation)
         except ParseException:
             failures += 1
-            print('Not patching %s as it has parse errors' % path)
+            print('Not patching {0!s} as it has parse errors'.format(path))
 
-    print('Patched %d files with HH_FIXME' % (len(fixmes) - failures))
+    print('Patched {0:d} files with HH_FIXME'.format((len(fixmes) - failures)))
 
     return 0
 

--- a/hphp/test/tools/import_spec_test.py
+++ b/hphp/test/tools/import_spec_test.py
@@ -111,7 +111,7 @@ def walk(filename, dest_subdir):
     # We'll only move things we want into 'good'
     shutil.copyfile(filename, full_dest_filename)
 
-    print("Importing %s" % full_dest_filename)
+    print("Importing {0!s}".format(full_dest_filename))
 
 def should_import(filename):
     for bad in no_import:

--- a/hphp/test/tools/import_zend_test.py
+++ b/hphp/test/tools/import_zend_test.py
@@ -1089,7 +1089,7 @@ def walk(filename, dest_subdir):
 
         return
 
-    print("Importing %s" % full_dest_filename)
+    print("Importing {0!s}".format(full_dest_filename))
 
     def split(pattern, str):
         return re.split(r'\n\s*--'+pattern+'--\s*\n', str, 1)
@@ -1113,7 +1113,7 @@ def walk(filename, dest_subdir):
     unsupported_sections = ('POST_RAW')
     for name in unsupported_sections:
         if name in sections:
-            print("Unsupported test with section --%s--: " % name, filename)
+            print("Unsupported test with section --{0!s}--: ".format(name), filename)
             return
 
     if not 'FILE' in sections:
@@ -1646,15 +1646,15 @@ def walk(filename, dest_subdir):
 
         for t, t_replace_config in replace_configs.items():
             for i, replace_id in enumerate(t_replace_config.get(testname, [])):
-                new_id = 'test_%s_%s_%d' % (testname, t, i + 1)
+                new_id = 'test_{0!s}_{1!s}_{2:d}'.format(testname, t, i + 1)
                 if isinstance(replace_id, str):
                     test = test.replace(replace_id, new_id)
                 else:
                     test = replace_id.sub(new_id, test)
 
-        new_id = 'test_%s_table_1' % (testname, )
+        new_id = 'test_{0!s}_table_1'.format(testname )
         test = re.sub('(require(_once)*[ (][\'"](clean_)?table.inc[\'"]\)?)',
-                      '$test_table_name = \'%s\'; \\1' % (new_id, ), test)
+                      '$test_table_name = \'{0!s}\'; \\1'.format(new_id ), test)
 
     open(full_dest_filename, 'w').write(test)
 

--- a/hphp/test/tools/move_good_tests.py
+++ b/hphp/test/tools/move_good_tests.py
@@ -115,5 +115,5 @@ if not args.no_move:
     if len(good_tests) == 0:
         print "\nNo good tests found"
     else:
-        print "\nMoving %d tests" % len(good_tests)
+        print "\nMoving {0:d} tests".format(len(good_tests))
         moveTests(good_tests)

--- a/hphp/tools/benchy/any_mean.py
+++ b/hphp/tools/benchy/any_mean.py
@@ -95,10 +95,10 @@ def print_means_and_cis(categories, widest_key):
         mean, interval = None, None
         if len(values) > 1:
             mean, interval = mean_confidence_interval(values)
-            print("%s: %s%.2f +-%.2f" % (key, padding, mean, interval))
+            print("{0!s}: {1!s}{2:.2f} +-{3:.2f}".format(key, padding, mean, interval))
         else:
             mean = arith_mean(values)
-            print("%s: %s%.2f" % (key, padding, mean))
+            print("{0!s}: {1!s}{2:.2f}".format(key, padding, mean))
             sys.stderr.write("Warning: too few samples to calculate confidence"
                              " interval for \"%s\"\n" % key)
 

--- a/hphp/tools/benchy/benchy.py
+++ b/hphp/tools/benchy/benchy.py
@@ -87,7 +87,7 @@ def parse_branches(raw_branches):
     for raw_branch in raw_branches:
         result = re.match(Branch.pattern, raw_branch)
         if result is None:
-            raise RuntimeError("Invalid branch format: %s" % raw_branch)
+            raise RuntimeError("Invalid branch format: {0!s}".format(raw_branch))
         name = result.group(1)
         if result.group(2) is None:
             branches.append(Branch(name))
@@ -154,8 +154,8 @@ def run_benchmarks(
     """
     benchy_path = config.HARNESS_PATH
 
-    suite_str = ' '.join(["--suite %s" % s for s in suites])
-    benchmark_str = ' '.join(["--benchmark %s" % b for b in benchmarks])
+    suite_str = ' '.join(["--suite {0!s}".format(s) for s in suites])
+    benchmark_str = ' '.join(["--benchmark {0!s}".format(b) for b in benchmarks])
     perf_str = '--perf' if run_perf else ''
     warmup_str = '' if warmup is None else '--warmup {0}'.format(warmup)
     inner_str = '' if inner is None else '--inner {0}'.format(inner)
@@ -185,7 +185,7 @@ def process_results(branches, output_mode):
 
     for branch in branches:
         counter += 1
-        runlog = os.path.join(config.WORK_DIR, "runlog.%d" % counter)
+        runlog = os.path.join(config.WORK_DIR, "runlog.{0:d}".format(counter))
         result_path = os.path.join(config.WORK_DIR, branch.result_file())
         with open(result_path, 'w') as result_file:
             cmd = "{anymean} --geomean {runlog}"

--- a/hphp/tools/benchy/benchy_config.py
+++ b/hphp/tools/benchy/benchy_config.py
@@ -46,7 +46,7 @@ def _load():
         _load.config['RUNLOG_PATH'] = os.path.join(work_dir, 'runlog')
         _load.config['PERF_PATH'] = os.path.join(work_dir, 'perf')
         _load.config['TMP_PATH'] = os.path.join(work_dir, 'tmp')
-        _load.config['PLATFORM'] = "%s_platform" % tmp['platform']
+        _load.config['PLATFORM'] = "{0!s}_platform".format(tmp['platform'])
     return _load.config
 _load.config = None
 

--- a/hphp/tools/benchy/benchy_harness.py
+++ b/hphp/tools/benchy/benchy_harness.py
@@ -326,7 +326,7 @@ def parse_virtual_machines(raw_vms):
     for raw_vm in raw_vms:
         result = re.match(VirtualMachine.pattern, raw_vm)
         if result is None:
-            raise RuntimeError("Invalid format for VM: %s" % raw_vm)
+            raise RuntimeError("Invalid format for VM: {0!s}".format(raw_vm))
         name = result.group('name')
         opts_path = result.group('opts_path').split(':')[1:]
         env, args = parse_opts(opts_path[:-1])

--- a/hphp/tools/benchy/fb_platform.py
+++ b/hphp/tools/benchy/fb_platform.py
@@ -27,7 +27,7 @@ class Platform(object):
         This function will always be invoked prior to building a branch.
 
         """
-        utils.run_command('arc feature %s' % branch.name)
+        utils.run_command('arc feature {0!s}'.format(branch.name))
 
     def build_branch(self, branch):
         """Builds the specified branch.

--- a/hphp/tools/benchy/oss_platform.py
+++ b/hphp/tools/benchy/oss_platform.py
@@ -33,7 +33,7 @@ class Platform(object):
         This function will always be invoked prior to building a branch.
 
         """
-        utils.run_command('git checkout %s' % branch.name)
+        utils.run_command('git checkout {0!s}'.format(branch.name))
 
     def build_branch(self, branch):
         """Builds the specified branch.
@@ -46,7 +46,7 @@ class Platform(object):
         try:
             print(build_dir)
             os.chdir(build_dir)
-            utils.run_command('cmake %s' % config.SRCROOT_PATH)
-            utils.run_command('make -j%d' % multiprocessing.cpu_count())
+            utils.run_command('cmake {0!s}'.format(config.SRCROOT_PATH))
+            utils.run_command('make -j{0:d}'.format(multiprocessing.cpu_count()))
         finally:
             os.chdir(before_dir)

--- a/hphp/tools/benchy/significance.py
+++ b/hphp/tools/benchy/significance.py
@@ -115,7 +115,7 @@ def print_results(result_files, out_format):
     geomean = None
     for key in categories:
         scores = [run[1] for run in categories[key]]
-        entries = ["%.2f +- %.2f" % score for score in scores]
+        entries = ["{0:.2f} +- {1:.2f}".format(*score) for score in scores]
         entries.insert(0, key)
         if key == 'Geomean':
             geomean = entries
@@ -133,7 +133,7 @@ def red(text):
     the provided text.
 
     """
-    return '\033[31m%s\033[39m' % text
+    return '\033[31m{0!s}\033[39m'.format(text)
 
 
 def green(text):
@@ -141,7 +141,7 @@ def green(text):
     wrapping the provided text.
 
     """
-    return '\033[32m%s\033[39m' % text
+    return '\033[32m{0!s}\033[39m'.format(text)
 
 
 def bold(out_format, text):
@@ -150,13 +150,13 @@ def bold(out_format, text):
 
     """
     if out_format == 'remarkup':
-        return "**%s**" % text
+        return "**{0!s}**".format(text)
     elif out_format == 'terminal':
-        return "\033[1m%s\033[0m" % text
+        return "\033[1m{0!s}\033[0m".format(text)
     elif out_format == 'json':
         return text
     else:
-        raise RuntimeError("Unknown output format: %s" % out_format)
+        raise RuntimeError("Unknown output format: {0!s}".format(out_format))
 
 
 def faster(out_format, text):
@@ -170,7 +170,7 @@ def faster(out_format, text):
     elif out_format == 'json':
         return text
     else:
-        raise RuntimeError("Unknown output format: %s" % out_format)
+        raise RuntimeError("Unknown output format: {0!s}".format(out_format))
 
 
 def slower(out_format, text):
@@ -184,7 +184,7 @@ def slower(out_format, text):
     elif out_format == 'json':
         return text
     else:
-        raise RuntimeError("Unknown output format: %s" % out_format)
+        raise RuntimeError("Unknown output format: {0!s}".format(out_format))
 
 
 def is_slower(change, lower_is_better):
@@ -211,17 +211,17 @@ def print_comparison_results(result_files, out_format, lower_is_better):
         """
         old_score, old_ci = scores[-2]
         new_score, new_ci = scores[-1]
-        entries = ["%.2f +- %.2f" % score for score in scores]
+        entries = ["{0:.2f} +- {1:.2f}".format(*score) for score in scores]
         entries.insert(0, key)
         if confidence_intervals_overlap(old_score, old_ci, new_score, new_ci):
             entries.append("")
         else:
             change = percent_delta(old_score, new_score)
             if is_slower(change, lower_is_better):
-                change_str = "%.4f%% slower" % (change * 100.0)
+                change_str = "{0:.4f}% slower".format((change * 100.0))
                 entries.append(slower(out_format, change_str))
             else:
-                change_str = "+%.4f%% faster" % (change * 100.0)
+                change_str = "+{0:.4f}% faster".format((change * 100.0))
                 entries.append(faster(out_format, change_str))
         return entries
 

--- a/hphp/tools/benchy/table.py
+++ b/hphp/tools/benchy/table.py
@@ -19,7 +19,7 @@ def _print_horizontal_line(max_widths):
     """
     for width in max_widths:
         dashes = '-' * width
-        sys.stdout.write("%s---" % dashes)
+        sys.stdout.write("{0!s}---".format(dashes))
     sys.stdout.write('-\n')
 
 def _print_entry_centered(entry, width):
@@ -29,7 +29,7 @@ def _print_entry_centered(entry, width):
     total_padding = width - _len_sans_ansi(entry)
     front_padding = ' ' * (total_padding // 2)
     back_padding = ' ' * (total_padding - len(front_padding))
-    sys.stdout.write("%s%s%s" % (front_padding, entry, back_padding))
+    sys.stdout.write("{0!s}{1!s}{2!s}".format(front_padding, entry, back_padding))
 
 def _print_entry_left(entry, width, filler=' '):
     """Prints a table entry left justified within its cell.
@@ -37,7 +37,7 @@ def _print_entry_left(entry, width, filler=' '):
     """
     total_padding = width - _len_sans_ansi(entry)
     back_padding = filler * total_padding
-    sys.stdout.write("%s%s" % (entry, back_padding))
+    sys.stdout.write("{0!s}{1!s}".format(entry, back_padding))
 
 def _len_sans_ansi(text):
     """Computes the length of a string that might contain ANSI codes.
@@ -89,7 +89,7 @@ class Table(object):
         elif out_format == 'json':
             self.dump_to_json()
         else:
-            raise RuntimeError("Unknown output format: %s" % out_format)
+            raise RuntimeError("Unknown output format: {0!s}".format(out_format))
 
     def dump_to_json(self):
         """Print the table in JSON format. The printed value will be an array

--- a/hphp/tools/convert_make_target_to_command.py
+++ b/hphp/tools/convert_make_target_to_command.py
@@ -32,7 +32,7 @@ root = home + '/' + os.getenv('FBMAKE_BIN_ROOT', '_bin')
 
 def main():
     if len(sys.argv) < 2:
-        print "%s [Quick|Slow|Zend][<blank>|Repo][VM|Jit|JitIR][-SubSuiteName]" % sys.argv[0]
+        print "{0!s} [Quick|Slow|Zend][<blank>|Repo][VM|Jit|JitIR][-SubSuiteName]".format(sys.argv[0])
         return
 
     arg = sys.argv[1]
@@ -54,14 +54,14 @@ def main():
                         if arg[0] == '-':
                             subpath = '/' + camel_to_slash(arg[1:])
                         else:
-                            raise Exception('Extra? "%s"' % arg)
+                            raise Exception('Extra? "{0!s}"'.format(arg))
 
                     path = relative_path('../test/' + dir + subpath)
                     return [relative_path('../test/run'), path, '-m', vq, repo]
 
-            raise Exception('Unknown mode "%s"' % arg)
+            raise Exception('Unknown mode "{0!s}"'.format(arg))
 
-    raise Exception('Unknown Suite "%s"' % arg)
+    raise Exception('Unknown Suite "{0!s}"'.format(arg))
 
 def camel_to_slash(name):
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1/\2', name)

--- a/hphp/tools/gdb/asio.py
+++ b/hphp/tools/gdb/asio.py
@@ -268,7 +268,7 @@ class InfoAsioCommand(gdb.Command):
         asio_ctx = asio_context()
 
         # Count the number of contexts, and print the topmost.
-        print('\n%d stacked AsioContext%s (current: (%s) %s)' % (
+        print('\n{0:d} stacked AsioContext{1!s} (current: ({2!s}) {3!s})'.format(
             int(num_contexts),
             plural_suffix(num_contexts),
             str(asio_ctx.type),
@@ -291,7 +291,7 @@ class InfoAsioCommand(gdb.Command):
 
         wh = fp['m_this'].cast(wh_ptype)
 
-        print('\nCurrently %s WaitHandle: (%s) %s [state: %s]' % (
+        print('\nCurrently {0!s} WaitHandle: ({1!s}) {2!s} [state: {3!s}]'.format(
             'joining' if i == 0 else 'executing',
             str(wh.type),
             str(wh),
@@ -299,11 +299,11 @@ class InfoAsioCommand(gdb.Command):
 
         # Dump the async stacktrace.
         for s in frame.stringify_stacktrace(asio_stacktrace(wh)):
-            print('    %s' % s)
+            print('    {0!s}'.format(s))
 
         # Count the number of queued runnables.
         queue_size = sizeof(asio_ctx['m_runnableQueue'])
-        print('%d other resumable%s queued' % (
+        print('{0:d} other resumable{1!s} queued'.format(
             int(queue_size),
             plural_suffix(queue_size)))
 
@@ -315,9 +315,9 @@ class InfoAsioCommand(gdb.Command):
 
         # Count sleep and external thread events.
         print('')
-        print('%d pending sleep event%s' % (
+        print('{0:d} pending sleep event{1!s}'.format(
             int(num_sleeps), plural_suffix(num_sleeps)))
-        print('%d pending external thread event%s' % (
+        print('{0:d} pending external thread event{1!s}'.format(
             int(num_externals), plural_suffix(num_externals)))
 
         # Dump sleep and external thread event stacktraces.
@@ -326,17 +326,17 @@ class InfoAsioCommand(gdb.Command):
                 wh = idx.vector_at(vec, i)
                 stacktrace = frame.stringify_stacktrace(asio_stacktrace(wh, 3))
 
-                print('\n(%s) %s [state: %s]' % (
+                print('\n({0!s}) {1!s} [state: {2!s}]'.format(
                     str(wh.type), str(wh), WaitHandle(wh).state_str()))
 
                 if len(stacktrace) == 4:
                     for s in stacktrace[0:-1]:
-                        print('    %s' % s)
+                        print('    {0!s}'.format(s))
                     print('     ...')
-                    print('    %s' % stacktrace[-1])
+                    print('    {0!s}'.format(stacktrace[-1]))
                 else:
                     for s in stacktrace:
-                        print('    %s' % s)
+                        print('    {0!s}'.format(s))
         print('')
 
 InfoAsioCommand()

--- a/hphp/tools/gdb/frame.py
+++ b/hphp/tools/gdb/frame.py
@@ -43,7 +43,7 @@ def php_line_number_from_repo(func, pc):
     # Query for the line table.
     c = conn.cursor()
     table = repo.table('UnitLineTable')
-    c.execute('SELECT data FROM %s WHERE unitSn == ?;' % table, (sn,))
+    c.execute('SELECT data FROM {0!s} WHERE unitSn == ?;'.format(table), (sn,))
 
     row = c.fetchone()
     if row is None:
@@ -155,7 +155,7 @@ def create_php(idx, ar, rip='0x????????', pc=None):
         'idx':  idx,
         'sp':   str(ar),
         'rip':  _format_rip(rip),
-        'func': '[PHP] %s()' % func_name,
+        'func': '[PHP] {0!s}()'.format(func_name),
     }
 
     attrs = idxs.atomic_get(func['m_attrs']['m_attrs'])
@@ -240,7 +240,7 @@ def stringify_stacktrace(stacktrace):
 def _format_rip(rip):
     """Hex-ify rip if it's an int-like gdb.Value."""
     try:
-        rip = '0x%08x' % int(str(rip))
+        rip = '0x{0:08x}'.format(int(str(rip)))
     except ValueError:
         rip = str(rip)
 

--- a/hphp/tools/gdb/gdbutils.py
+++ b/hphp/tools/gdb/gdbutils.py
@@ -71,7 +71,7 @@ def parse_argv(args):
 def gdbprint(val, ty=None):
     if ty is None:
         ty = val.type
-    gdb.execute('print (%s)%s' % (str(ty), str(val)))
+    gdb.execute('print ({0!s}){1!s}'.format(str(ty), str(val)))
 
 
 def plural_suffix(num, suffix='s'):

--- a/hphp/tools/gdb/hhbc.py
+++ b/hphp/tools/gdb/hhbc.py
@@ -233,7 +233,7 @@ remains where it left off after the previous call.
             instr = HHBC.instr_info(self.bcpos)
             name = HHBC.op_name(self.bcpos.dereference()).string()
 
-            out = "%s+%d: %s" % (str(bcstart), self.bcoff, name)
+            out = "{0!s}+{1:d}: {2!s}".format(str(bcstart), self.bcoff, name)
             for imm in instr['imms']:
                 if type(imm) is str:
                     pass

--- a/hphp/tools/gdb/idx.py
+++ b/hphp/tools/gdb/idx.py
@@ -307,7 +307,7 @@ If `container' is of a recognized type (e.g., native arrays, std::vector),
             print('idx: Element not found.')
             return None
 
-        gdb.execute('print *(%s)%s' % (
+        gdb.execute('print *({0!s}){1!s}'.format(
             str(value.type.pointer()), str(value.address)))
 
 

--- a/hphp/tools/gdb/pretty.py
+++ b/hphp/tools/gdb/pretty.py
@@ -95,15 +95,15 @@ class TypedValuePrinter(object):
             val = data['pref'].dereference()
 
         else:
-            t = 'Invalid(%d)' % t.cast(T('int8_t'))
-            val = "0x%x" % data['num']
+            t = 'Invalid({0:d})'.format(t.cast(T('int8_t')))
+            val = "0x{0:x}".format(data['num'])
 
         if val is None:
-            out = '{ %s }' % t
+            out = '{{ {0!s} }}'.format(t)
         elif name is None:
-            out = '{ %s, %s }' % (t, str(val))
+            out = '{{ {0!s}, {1!s} }}'.format(t, str(val))
         else:
-            out = '{ %s, %s ("%s") }' % (t, str(val), name)
+            out = '{{ {0!s}, {1!s} ("{2!s}") }}'.format(t, str(val), name)
 
         return out
 
@@ -123,8 +123,8 @@ class PtrPrinter(object):
     def to_string(self):
         s = self._string()
 
-        out = '(%s) %s'  % (str(self._ptype()), str(self._pointer()))
-        return '%s "%s"' % (out, s) if s is not None else out
+        out = '({0!s}) {1!s}'.format(str(self._ptype()), str(self._pointer()))
+        return '{0!s} "{1!s}"'.format(out, s) if s is not None else out
 
 
 class ReqPtrPrinter(PtrPrinter):
@@ -195,7 +195,7 @@ class ArrayDataPrinter(object):
                 raise StopIteration
 
             elt = self.cur
-            key = '%d' % self.count
+            key = '{0:d}'.format(self.count)
 
             try:
                 data = elt.dereference()
@@ -221,9 +221,9 @@ class ArrayDataPrinter(object):
                 if elt['data']['m_type'] == -1:
                     key = '<deleted>'
                 elif elt['data']['m_aux']['u_hash'] < 0:
-                    key = '%d' % elt['ikey']
+                    key = '{0:d}'.format(elt['ikey'])
                 else:
-                    key = '"%s"' % string_data_val(elt['skey'].dereference())
+                    key = '"{0!s}"'.format(string_data_val(elt['skey'].dereference()))
             except gdb.MemoryError:
                 key = '<invalid>'
 
@@ -251,16 +251,16 @@ class ArrayDataPrinter(object):
         kind_int = int(self.kind.cast(T('uint8_t')))
 
         if kind_int > 9:
-            return 'Invalid ArrayData (kind=%d)' % kind_int
+            return 'Invalid ArrayData (kind={0:d})'.format(kind_int)
 
         if self.kind == self._kind('Proxy'):
-            return 'ProxyArray { %s }' % (
+            return 'ProxyArray {{ {0!s} }}'.format((
                 self.val['m_ref'].dereference()['m_tv']
-                        ['m_data']['parr'].dereference())
+                        ['m_data']['parr'].dereference()))
 
         kind = str(self.kind)[len('HPHP::ArrayData::'):]
 
-        return "ArrayData[%s]: %d element(s) refcount=%d" % (
+        return "ArrayData[{0!s}]: {1:d} element(s) refcount={2:d}".format(
             kind,
             self.val['m_size'],
             self.val['m_hdr']['count']
@@ -322,7 +322,7 @@ class ObjectDataPrinter(object):
         self.cls = deref(val['m_cls'])
 
     def to_string(self):
-        return 'Object of class "%s" @ %s' % (
+        return 'Object of class "{0!s}" @ {1!s}'.format(
             nameof(self.cls),
             self.val.address)
 
@@ -340,7 +340,7 @@ class RefDataPrinter(object):
         self.val = val
 
     def to_string(self):
-        return "RefData { %s }" % self.val['m_tv']
+        return "RefData {{ {0!s} }}".format(self.val['m_tv'])
 
 
 #------------------------------------------------------------------------------

--- a/hphp/tools/gdb/repo.py
+++ b/hphp/tools/gdb/repo.py
@@ -41,7 +41,7 @@ def set(repo_id, path):
 
 
 def table(prefix):
-    return '%s_%s' % (prefix, K('HPHP::kRepoSchemaId').string())
+    return '{0!s}_{1!s}'.format(prefix, K('HPHP::kRepoSchemaId').string())
 
 
 #------------------------------------------------------------------------------
@@ -102,8 +102,8 @@ class RepoShowCommand(gdb.Command):
     @errorwrap
     def invoke(self, args, from_tty):
         global _paths
-        print('Central repo: %s' % '<none>' if _paths[0] is None else _paths[0])
-        print('Local repo: %s'   % '<none>' if _paths[1] is None else _paths[1])
+        print('Central repo: {0!s}'.format('<none>') if _paths[0] is None else _paths[0])
+        print('Local repo: {0!s}'.format('<none>') if _paths[1] is None else _paths[1])
 
 
 class RepoSetCentralCommand(gdb.Command):
@@ -121,7 +121,7 @@ class RepoSetCentralCommand(gdb.Command):
             return
 
         set(V('HPHP::RepoIdCentral'), argv[0])
-        print('Set central repo to %s' % argv[0])
+        print('Set central repo to {0!s}'.format(argv[0]))
 
 
 class RepoSetLocalCommand(gdb.Command):
@@ -139,7 +139,7 @@ class RepoSetLocalCommand(gdb.Command):
             return
 
         set(V('HPHP::RepoIdLocal'), argv[0])
-        print('Set local repo to %s' % argv[0])
+        print('Set local repo to {0!s}'.format(argv[0]))
 
 
 RepoCommand()

--- a/hphp/tools/out2expectf.py
+++ b/hphp/tools/out2expectf.py
@@ -15,21 +15,21 @@ root_re = re.escape(root)
 
 for test in sys.argv[1:]:
     if not test.endswith('.php'):
-        print("%s doesn\'t end in .php. Pass the .php file to this script." %
-               test)
+        print("{0!s} doesn\'t end in .php. Pass the .php file to this script.".format(
+               test))
         sys.exit(1)
 
     try:
         data = open(test + '.out').read()
     except IOError:
-        print("%s.out doesn't exist, skipping" % test)
+        print("{0!s}.out doesn't exist, skipping".format(test))
         continue
 
     try:
         # the first match has to be in a try incase there is bad unicode
         re.sub('a', r'a', data)
     except UnicodeDecodeError:
-        print("%s has invalid unicode, skipping" % test)
+        print("{0!s} has invalid unicode, skipping".format(test))
         continue
 
     # try to do relative paths
@@ -63,4 +63,4 @@ for test in sys.argv[1:]:
         name = test + '.expect'
 
     open(name, 'w').write(data)
-    print('Copied %s.out to %s' % (test, name))
+    print('Copied {0!s}.out to {1!s}'.format(test, name))

--- a/hphp/zend/html_tables/generate-html-table.py
+++ b/hphp/zend/html_tables/generate-html-table.py
@@ -37,16 +37,16 @@ def add_basic_codes(file_name):
 
 def write_table(table_name, table_data):
     table_data.sort()
-    print 'static const entity_doctype_table_t %s {' % table_name
+    print 'static const entity_doctype_table_t {0!s} {{'.format(table_name)
     for code_point, entity in table_data:
-        print '  {%s, "%s"},' % (hex(code_point), entity)
+        print '  {{{0!s}, "{1!s}"}},'.format(hex(code_point), entity)
     print '};'
     print
 
 def write_mapping_table(table_name, table_data):
-    print 'static const charset_table_t %s {' % table_name
+    print 'static const charset_table_t {0!s} {{'.format(table_name)
     for a, b in table_data:
-        print '  {%s, %s},' % (hex(a), hex(b))
+        print '  {{{0!s}, {1!s}}},'.format(hex(a), hex(b))
     print '};'
     print
 
@@ -132,9 +132,9 @@ def read_multicode_table(file_name):
 
 def write_multicode_table(table_name, table_data):
     table_data.sort()
-    print 'static const entity_multicode_table_t %s {' % table_name
+    print 'static const entity_multicode_table_t {0!s} {{'.format(table_name)
     for ((code1, code2), entity) in table_data:
-        print '  {{%s, %s}, "%s"},' % (hex(code1), hex(code2), entity)
+        print '  {{{{{0!s}, {1!s}}}, "{2!s}"}},'.format(hex(code1), hex(code2), entity)
     print '};'
     print
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:hhvm?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:hhvm?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
